### PR TITLE
Fix "Service is not defined" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,6 +299,8 @@ LIFxBulbAccessory.prototype = {
 module.exports.accessory = LIFxBulbAccessory;
 module.exports.platform = LIFxPlatform;
 
+var Service, Characteristic;
+
 module.exports = function(homebridge) {
   Service = homebridge.hap.Service;
   Characteristic = homebridge.hap.Characteristic;


### PR DESCRIPTION
Loaded plugin: homebridge-lifx
/usr/lib/node_modules/homebridge-lifx/index.js:303
  Service = homebridge.hap.Service;
          ^
ReferenceError: Service is not defined
    at Plugin.module.exports [as initializer](/usr/lib/node_modules/homebridge-lifx/index.js:303:11)
    at Server.<anonymous> (/usr/lib/node_modules/homebridge/lib/server.js:88:14)
    at Array.forEach (native)
    at Server._loadPlugins (/usr/lib/node_modules/homebridge/lib/server.js:66:22)
    at new Server (/usr/lib/node_modules/homebridge/lib/server.js:24:24)
    at module.exports (/usr/lib/node_modules/homebridge/lib/cli.js:23:3)
    at Object.<anonymous> (/usr/lib/node_modules/homebridge/bin/homebridge:17:22)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
