### PR TITLE
Fix issue #7 - setting colors works again

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,10 +158,10 @@ LIFxBulbAccessory.prototype = {
             hue: bulb.state.hue,
             saturation: bulb.state.saturation,
             brightness: bulb.state.brightness,
-            kelvin: bulb.state.kelvin
+            kelvin: 5500
         };
 
-        var scale = {hue: 360, saturation: 100, brightness, 100, kelvin: 65535}[type];
+        var scale = {hue: 360, saturation: 100, brightness: 100, kelvin: 65535}[type];
 
         state[type] = Math.round(value * 65535 / scale) & 0xffff;
         lifx_lan.lightsColour(state.hue, state.saturation, state.brightness, state.kelvin, 0, bulb);

--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ LIFxBulbAccessory.prototype = {
             kelvin: bulb.state.kelvin
         };
 
-        var scale = type == "hue" ? 360 : 100;
+        var scale = {hue: 360, saturation: 100, brightness, 100, kelvin: 65535}[type];
 
         state[type] = Math.round(value * 65535 / scale) & 0xffff;
         lifx_lan.lightsColour(state.hue, state.saturation, state.brightness, state.kelvin, 0, bulb);


### PR DESCRIPTION
These changes resolve issue #7. Kelvin values were being scaled out of valid range before, and I suspect a firmware update or a change to lifxjs made these wrong values cause updates to fail. As HomeKit devices don't seem to transmit kelvin updates, I've hard coded a sensible default of 5500° for now. This should also avoid the problem where different bulbs portray a vastly different white, if they've been set using other LIFX apps that manipulated the kelvin value in each bulb to different values.