### PR TITLE
Add fade duration config

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@
 //         "platform": "LIFx",             // required
 //         "name": "LIFx",                 // required
 //         "access_token": "access token", // required
-//         "use_lan": "true"               // optional set to "true" (gets and sets over the lan) or "get" (gets only over the lan)
+//         "use_lan": "true",              // optional set to "true" (gets and sets over the lan) or "get" (gets only over the lan)
+//         "fade_duration": 1.0            // optional gradually fade for a number of seconds (default is 0)
 //     }
 // ],
 //
@@ -22,6 +23,7 @@ var lifx_remote;
 var lifxLanObj;
 var lifx_lan;
 var use_lan;
+var fade_duration;
 
 function LIFxPlatform(log, config){
     // auth info
@@ -31,10 +33,13 @@ function LIFxPlatform(log, config){
 
     // use remote or lan api ?
     use_lan = config["use_lan"] || false;
+    fade_duration = config["fade_duration"] || 0;
 
     if (use_lan != false) {
         lifxLanObj = require('lifx');
         lifx_lan = lifxLanObj.init();
+        // convert fade_duration to milliseconds
+        fade_duration = Math.round(fade_duration * 1000);
     }
 
     this.log = log;
@@ -164,7 +169,7 @@ LIFxBulbAccessory.prototype = {
         var scale = {hue: 360, saturation: 100, brightness: 100, kelvin: 65535}[type];
 
         state[type] = Math.round(value * 65535 / scale) & 0xffff;
-        lifx_lan.lightsColour(state.hue, state.saturation, state.brightness, state.kelvin, 0, bulb);
+        lifx_lan.lightsColour(state.hue, state.saturation, state.brightness, state.kelvin, fade_duration, bulb);
 
         callback(null);
     },
@@ -202,7 +207,7 @@ LIFxBulbAccessory.prototype = {
                 break;
         }
 
-        lifx_remote.setColor("id:"+ this.deviceId, color, 0, null, function (body) {
+        lifx_remote.setColor("id:"+ this.deviceId, color, fade_duration, null, function (body) {
             callback();
         });
     },
@@ -210,7 +215,7 @@ LIFxBulbAccessory.prototype = {
         var that = this;
 
         this.log("Setting remote power: " + state);
-        lifx_remote.setPower("id:"+ that.deviceId, (state == 1 ? "on" : "off"), 0, function (body) {
+        lifx_remote.setPower("id:"+ that.deviceId, (state == 1 ? "on" : "off"), fade_duration, function (body) {
             callback();
         });
     },

--- a/index.js
+++ b/index.js
@@ -158,10 +158,10 @@ LIFxBulbAccessory.prototype = {
             hue: bulb.state.hue,
             saturation: bulb.state.saturation,
             brightness: bulb.state.brightness,
-            kelvin: bulb.state.kelvin
+            kelvin: 5500
         };
 
-        var scale = {hue: 360, saturation: 100, brightness, 100, kelvin: 65535}[type];
+        var scale = {hue: 360, saturation: 100, brightness: 100, kelvin: 65535}[type];
 
         state[type] = Math.round(value * 65535 / scale) & 0xffff;
         lifx_lan.lightsColour(state.hue, state.saturation, state.brightness, state.kelvin, 0, bulb);

--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ LIFxBulbAccessory.prototype = {
             kelvin: bulb.state.kelvin
         };
 
-        var scale = type == "hue" ? 360 : 100;
+        var scale = {hue: 360, saturation: 100, brightness, 100, kelvin: 65535}[type];
 
         state[type] = Math.round(value * 65535 / scale) & 0xffff;
         lifx_lan.lightsColour(state.hue, state.saturation, state.brightness, state.kelvin, 0, bulb);


### PR DESCRIPTION
Allows users to configure fading.

Due to a limitation of the very outdated lifx lan library in use, fading duration cannot be specified in lan mode for power (on/off) changes.

Would you consider a pull request which strips out lifxjs and replaces it with the more up to date "node-lifx" for lan support? It follows the public specification of the LAN API, instead of using the outdated and deprecated private APIs lifxjs gleaned from sniffing the original smartphone apps when they first came out. The only downside I see to this, is node-lifx only supports bulbs running firmware 2.0 or above, so users who have never updated their original kickstarter bulbs would require a software update. I don't think this would affect many users.